### PR TITLE
Add functions to write a sensible default caboose

### DIFF
--- a/hubtools/Cargo.toml
+++ b/hubtools/Cargo.toml
@@ -11,3 +11,6 @@ thiserror.version = "1"
 toml.version = "0.7"
 zerocopy.version = "0.6"
 zip.version = "0.5.13"
+
+tlvc.git = "https://github.com/oxidecomputer/tlvc"
+tlvc-text.git = "https://github.com/oxidecomputer/tlvc"


### PR DESCRIPTION
Here's an example of what this produces:
```
[
    ("GITC", [
        "3642072b886fb76b1312afc25aad3333ac9b5cba-dirty",
    ]),
    ("BORD", [
        "stm32g070",
    ]),
    ("NAME", [
        "demo-stm32g070-nucleo",
    ]),
    ("VERS", [
        "0.1.3",
    ]),
]
```
(taking roughly 156 bytes)