### PR TITLE
Refactoring and cleanup

### DIFF
--- a/hubedit/src/main.rs
+++ b/hubedit/src/main.rs
@@ -4,7 +4,7 @@
 
 use anyhow::{anyhow, bail, Result};
 use clap::Parser;
-use hubtools::RawHubrisImage;
+use hubtools::RawHubrisArchive;
 
 #[derive(Parser, Debug)]
 #[clap(name = "hubedit", max_term_width = 80)]
@@ -39,7 +39,7 @@ pub enum Command {
 
 fn main() -> Result<()> {
     let args = Args::parse();
-    let mut archive = RawHubrisImage::load(&args.archive)?;
+    let mut archive = RawHubrisArchive::load(&args.archive)?;
 
     match args.cmd {
         Command::ReadCaboose => {

--- a/hubtools/Cargo.toml
+++ b/hubtools/Cargo.toml
@@ -4,10 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ihex = "3.0"
 object = { version = "0.30", default-features = false, features = ["write", "read"] }
 path-slash = "0.1"
-srec = "0.2.0"
 thiserror = "1"
 toml = "0.7"
 zerocopy = "0.6"

--- a/hubtools/Cargo.toml
+++ b/hubtools/Cargo.toml
@@ -4,14 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+ihex = "3.0"
 object = { version = "0.30", default-features = false, features = ["write"] }
-path-slash.version = "0.1"
-srec.version = "0.2.0"
-tempfile.version = "3"
-thiserror.version = "1"
-toml.version = "0.7"
-zerocopy.version = "0.6"
-zip.version = "0.5.13"
+path-slash = "0.1"
+srec = "0.2.0"
+tempfile = "3"
+thiserror = "1"
+toml = "0.7"
+zerocopy = "0.6"
+zip = "0.5.13"
 
 tlvc.git = "https://github.com/oxidecomputer/tlvc"
 tlvc-text.git = "https://github.com/oxidecomputer/tlvc"

--- a/hubtools/Cargo.toml
+++ b/hubtools/Cargo.toml
@@ -5,10 +5,9 @@ edition = "2021"
 
 [dependencies]
 ihex = "3.0"
-object = { version = "0.30", default-features = false, features = ["write"] }
+object = { version = "0.30", default-features = false, features = ["write", "read"] }
 path-slash = "0.1"
 srec = "0.2.0"
-tempfile = "3"
 thiserror = "1"
 toml = "0.7"
 zerocopy = "0.6"

--- a/hubtools/Cargo.toml
+++ b/hubtools/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+object = { version = "0.30", default-features = false, features = ["write"] }
 path-slash.version = "0.1"
 srec.version = "0.2.0"
 tempfile.version = "3"

--- a/hubtools/src/lib.rs
+++ b/hubtools/src/lib.rs
@@ -52,6 +52,22 @@ impl RawHubrisImage {
         })
     }
 
+    pub fn from_binary(
+        data: &[u8],
+        start_addr: u32,
+        kentry: u32,
+    ) -> Result<Self, Error> {
+        let mut segments = BTreeMap::new();
+        segments.insert(
+            start_addr,
+            LoadSegment {
+                source_file: "".into(),
+                data: data.to_vec(),
+            },
+        );
+        Self::from_segments(&segments, kentry, 0xFF)
+    }
+
     pub fn from_elf(elf_data: &[u8]) -> Result<Self, Error> {
         // TODO: check for memory range overlaps here
         let elf = object::read::File::parse(elf_data)?;
@@ -90,8 +106,8 @@ impl RawHubrisImage {
 
         // The order in which we do things is taken from
         // `object/src/write/elf/object.rs:elf_write`, but this is dramatically
-        // simpler: we're writing a single section with no relocations, symbols, or
-        // other fanciness (other than .shstrtab)
+        // simpler: we're writing a single section with no relocations, symbols,
+        // or other fanciness (other than .shstrtab)
         let header = object::write::elf::FileHeader {
             abi_version: 0,
             e_entry: self.kentry as u64,

--- a/hubtools/src/lib.rs
+++ b/hubtools/src/lib.rs
@@ -377,7 +377,7 @@ impl RawHubrisImage {
         // We'll use a temporary file to create modified object files, because
         // we build them with `arm-none-eabi-objcopy`
         let temp_dir = tempfile::tempdir().map_err(Error::TempDirError)?;
-        let srec = binary_to_srec(&self.data, "final.bin", self.kentry)?;
+        let srec = binary_to_srec(&self.data, "final.bin", self.start_addr)?;
         write_srec(&srec, self.kentry, &temp_dir.path().join("final.srec"))?;
         translate_srec_to_other_formats(temp_dir.path(), "final")?;
 
@@ -569,11 +569,11 @@ pub fn load_srec(
 pub fn binary_to_srec(
     binary: &[u8],
     name: &str,
-    bin_addr: u32,
+    start_addr: u32,
 ) -> Result<BTreeMap<u32, LoadSegment>, Error> {
     let mut srec_out = BTreeMap::new();
 
-    let mut addr = bin_addr;
+    let mut addr = start_addr;
     for chunk in binary.chunks(255 - 5) {
         srec_out.insert(
             addr,

--- a/hubtools/src/lib.rs
+++ b/hubtools/src/lib.rs
@@ -135,6 +135,7 @@ impl RawHubrisImage {
         w.write_shstrtab_section_header();
 
         debug_assert_eq!(w.reserved_len(), w.len());
+        // TODO: add PHDR with load info
 
         Ok(out)
     }


### PR DESCRIPTION
This PR started as an attempt to improve how we handle the internal segment maps, and quickly spiraled out of control.

Broadly, the PR implements a new workflow:

- ELF files are loaded into a `RawHubrisImage`
- Internally, a `RawHubrisImage` is a `Vec<u8>` of flash contents, a starting address, and a kernel entry point
- A `RawHubrisImage` can be converted back into ELF or `.bin`

This can happen either inside or outside of a `RawHubrisArchive`; `hubedit` uses the former, and Hubris' build system uses the latter.

Note that this eliminates the IHEX and SREC files from the Hubris archive!  This is fine; no one was using them anyways (Humility generates them on-demand from the ELF).