### PR TITLE
Add LPC55 operations

### DIFF
--- a/hubedit/src/main.rs
+++ b/hubedit/src/main.rs
@@ -35,6 +35,10 @@ pub enum Command {
         #[clap(short, long)]
         force: bool,
     },
+    VerifyImage {
+        #[clap(short, long)]
+        verbose: bool,
+    },
 }
 
 fn main() -> Result<()> {
@@ -84,6 +88,9 @@ fn main() -> Result<()> {
             }
             archive.erase_caboose()?;
             archive.overwrite()?;
+        }
+        Command::VerifyImage { verbose } => {
+            archive.verify(verbose)?;
         }
     }
 

--- a/hubtools/Cargo.toml
+++ b/hubtools/Cargo.toml
@@ -13,3 +13,4 @@ zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 
 tlvc = { git = "https://github.com/oxidecomputer/tlvc", default-features = false }
 tlvc-text = { git = "https://github.com/oxidecomputer/tlvc", default-features = false }
+lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }

--- a/hubtools/Cargo.toml
+++ b/hubtools/Cargo.toml
@@ -2,6 +2,7 @@
 name = "hubtools"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.66"
 
 [dependencies]
 object = { version = "0.30", default-features = false, features = ["write", "read"] }

--- a/hubtools/Cargo.toml
+++ b/hubtools/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 object = { version = "0.30", default-features = false, features = ["write", "read"] }
+packed_struct = { version = "0.10", default-features = false, features = ["std"] }
 path-slash = { version = "0.1", default-features = false }
 thiserror = { version = "1", default-features = false }
 toml = { version = "0.7", default-features = false, features = ["parse"] }
@@ -13,4 +14,5 @@ zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 
 tlvc = { git = "https://github.com/oxidecomputer/tlvc", default-features = false }
 tlvc-text = { git = "https://github.com/oxidecomputer/tlvc", default-features = false }
-lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }
+lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false, branch = "library-ify" }
+lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false, branch = "library-ify" }

--- a/hubtools/Cargo.toml
+++ b/hubtools/Cargo.toml
@@ -14,5 +14,5 @@ zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 
 tlvc = { git = "https://github.com/oxidecomputer/tlvc", default-features = false }
 tlvc-text = { git = "https://github.com/oxidecomputer/tlvc", default-features = false }
-lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false, branch = "library-ify" }
-lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false, branch = "library-ify" }
+lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false, version = "0.2" }
+lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false, version = "0.2" }

--- a/hubtools/src/lib.rs
+++ b/hubtools/src/lib.rs
@@ -739,6 +739,7 @@ impl RawHubrisArchive {
         debug: lpc55_areas::DebugSettings,
         default_isp: lpc55_areas::DefaultIsp,
         speed: lpc55_areas::BootSpeed,
+        boot_error_pin: lpc55_areas::BootErrorPin,
         root_certs: Vec<Vec<u8>>,
     ) -> Result<(), Error> {
         let rkth = lpc55_sign::signed_image::root_key_table_hash(root_certs)?;
@@ -748,6 +749,7 @@ impl RawHubrisArchive {
             debug,
             default_isp,
             speed,
+            boot_error_pin,
             rkth,
         )?;
         const CMPA_FILE: &str = "img/CMPA.bin";

--- a/hubtools/src/lib.rs
+++ b/hubtools/src/lib.rs
@@ -720,10 +720,21 @@ impl RawHubrisArchive {
     pub fn set_cmpa(
         &mut self,
         dice: lpc55_sign::signed_image::DiceArgs,
+        enable_secure_boot: bool,
+        debug: lpc55_areas::DebugSettings,
+        default_isp: lpc55_areas::DefaultIsp,
+        speed: lpc55_areas::BootSpeed,
         root_certs: Vec<Vec<u8>>,
     ) -> Result<(), Error> {
         let rkth = lpc55_sign::signed_image::root_key_table_hash(root_certs)?;
-        let cmpa = lpc55_sign::signed_image::generate_cmpa(dice, rkth)?;
+        let cmpa = lpc55_sign::signed_image::generate_cmpa(
+            dice,
+            enable_secure_boot,
+            debug,
+            default_isp,
+            speed,
+            rkth,
+        )?;
         const CMPA_FILE: &str = "img/CMPA.bin";
         if self.new_files.contains_key(CMPA_FILE)
             || self.extract_file(CMPA_FILE).is_ok()
@@ -739,8 +750,12 @@ impl RawHubrisArchive {
     ///
     /// This modifies local data in memory; call `self.overwrite` to persist
     /// changes back to the archive on disk.
-    pub fn set_cfpa(&mut self, root_certs: Vec<Vec<u8>>) -> Result<(), Error> {
-        let cfpa = lpc55_sign::signed_image::generate_cfpa(root_certs)?;
+    pub fn set_cfpa(
+        &mut self,
+        settings: lpc55_areas::DebugSettings,
+        revoke: [lpc55_areas::ROTKeyStatus; 4],
+    ) -> Result<(), Error> {
+        let cfpa = lpc55_sign::signed_image::generate_cfpa(settings, revoke)?;
         const CFPA_FILE: &str = "img/CFPA.bin";
         if self.new_files.contains_key(CFPA_FILE)
             || self.extract_file(CFPA_FILE).is_ok()


### PR DESCRIPTION
This PR adds support for LPC55 operations, e.g. signing and verifying images.

It needs to be merged after https://github.com/oxidecomputer/lpc55_support/pull/31