### PR TITLE
Tolerate old and new magic numbers

### DIFF
--- a/hubtools/src/lib.rs
+++ b/hubtools/src/lib.rs
@@ -755,6 +755,7 @@ impl RawHubrisArchive {
             speed,
             boot_error_pin,
             rkth,
+            false,
         )?;
         if self.new_files.contains_key(CMPA_FILE)
             || self.extract_file(CMPA_FILE).is_ok()

--- a/hubtools/src/lib.rs
+++ b/hubtools/src/lib.rs
@@ -274,7 +274,9 @@ pub enum Error {
     #[error("manifest decoding error: {0}")]
     BadManifest(std::str::Utf8Error),
 
-    #[error("could not find magic number {0:#x}")]
+    #[error(
+        "can't find header to locate caboose (missing magic number {0:#x})"
+    )]
     MissingMagic(u32),
 
     #[error("caboose is not present in this image")]


### PR DESCRIPTION
With the RFD374 stage0 transition, Hubris archives will sport one of two magic numbers to frighten and confuse old-stage0. The header layouts are the same, though, so the impact to hubtools is limited to teaching it that either number is okay.

While I was here, though, I also marginally improved diagnostics in the event of a magic number mismatch, since that's how I got here in the first place.