### PR TITLE
Use new x509_cert::Certificate interface to lpc55_sign

### DIFF
--- a/hubtools/Cargo.toml
+++ b/hubtools/Cargo.toml
@@ -16,6 +16,5 @@ zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 
 tlvc = { git = "https://github.com/oxidecomputer/tlvc", default-features = false }
 tlvc-text = { git = "https://github.com/oxidecomputer/tlvc", default-features = false }
-# TODO: remove branch once lpc55_support#58 merges
-lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", branch = "rust-crypto", default-features = false, version = "0.2" }
-lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", branch = "rust-crypto", default-features = false, version = "0.2" }
+lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false, version = "0.2" }
+lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false, version = "0.2" }

--- a/hubtools/Cargo.toml
+++ b/hubtools/Cargo.toml
@@ -10,10 +10,12 @@ packed_struct = { version = "0.10", default-features = false, features = ["std"]
 path-slash = { version = "0.1", default-features = false }
 thiserror = { version = "1", default-features = false }
 toml = { version = "0.7", default-features = false, features = ["parse"] }
+x509-cert = { version = "0.2", default-features = false, features = ["std"] }
 zerocopy = { version = "0.6", default-features = false }
 zip = { version = "0.6", default-features = false, features = ["bzip2"] }
 
 tlvc = { git = "https://github.com/oxidecomputer/tlvc", default-features = false }
 tlvc-text = { git = "https://github.com/oxidecomputer/tlvc", default-features = false }
-lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false, version = "0.2" }
-lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false, version = "0.2" }
+# TODO: remove branch once lpc55_support#58 merges
+lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", branch = "rust-crypto", default-features = false, version = "0.2" }
+lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", branch = "rust-crypto", default-features = false, version = "0.2" }


### PR DESCRIPTION
Also support the new `use_rsa_4096` flag to `generate_cmpa` and the new `image_key_revoke` argument to `generate_cfpa`.

Depends on [lpc55_support#58](https://github.com/oxidecomputer/lpc55_support/pull/58).