### PR TITLE
Add utilities to make hubtools suitable for use in MGS

### DIFF
--- a/hubtools/src/caboose.rs
+++ b/hubtools/src/caboose.rs
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::mem;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum CabooseError {
+    #[error("error reading caboose: {0:?}")]
+    TlvcReadError(tlvc::TlvcReadError),
+
+    #[error("caboose missing expected tag {tag:?}")]
+    MissingTag { tag: [u8; 4] },
+}
+
+#[derive(Debug, Clone)]
+pub struct Caboose {
+    raw: Vec<u8>,
+}
+
+impl Caboose {
+    pub(crate) fn new(raw: Vec<u8>) -> Self {
+        Self { raw }
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.raw
+    }
+
+    pub fn board(&self) -> Result<&[u8], CabooseError> {
+        use tlvc::TlvcReader;
+        let mut reader = TlvcReader::begin(self.as_slice())
+            .map_err(CabooseError::TlvcReadError)?;
+
+        while let Ok(Some(chunk)) = reader.next() {
+            if chunk.header().tag != tags::BORD {
+                continue;
+            }
+
+            let mut buf = [0; 32];
+            chunk
+                .check_body_checksum(&mut buf)
+                .map_err(CabooseError::TlvcReadError)?;
+
+            // At this point, the reader is positioned **after** the data
+            // from the target chunk.  We'll back up to the start of the
+            // data slice.
+            let (data, pos, _end) = reader.into_inner();
+
+            let pos = pos as usize;
+            let data_len = chunk.header().len.get() as usize;
+            let data_start = pos - chunk.header().total_len_in_bytes()
+                + mem::size_of::<tlvc::ChunkHeader>();
+            return Ok(&data[data_start..][..data_len]);
+        }
+
+        Err(CabooseError::MissingTag { tag: tags::BORD })
+    }
+}
+
+pub(crate) mod tags {
+    pub(crate) const GITC: [u8; 4] = *b"GITC";
+    pub(crate) const BORD: [u8; 4] = *b"BORD";
+    pub(crate) const NAME: [u8; 4] = *b"NAME";
+    pub(crate) const VERS: [u8; 4] = *b"VERS";
+}

--- a/hubtools/src/caboose.rs
+++ b/hubtools/src/caboose.rs
@@ -28,13 +28,29 @@ impl Caboose {
         &self.raw
     }
 
+    pub fn git_commit(&self) -> Result<&[u8], CabooseError> {
+        self.get_tag(tags::GITC)
+    }
+
     pub fn board(&self) -> Result<&[u8], CabooseError> {
+        self.get_tag(tags::BORD)
+    }
+
+    pub fn name(&self) -> Result<&[u8], CabooseError> {
+        self.get_tag(tags::NAME)
+    }
+
+    pub fn version(&self) -> Result<&[u8], CabooseError> {
+        self.get_tag(tags::VERS)
+    }
+
+    fn get_tag(&self, tag: [u8; 4]) -> Result<&[u8], CabooseError> {
         use tlvc::TlvcReader;
         let mut reader = TlvcReader::begin(self.as_slice())
             .map_err(CabooseError::TlvcReadError)?;
 
         while let Ok(Some(chunk)) = reader.next() {
-            if chunk.header().tag != tags::BORD {
+            if chunk.header().tag != tag {
                 continue;
             }
 
@@ -55,7 +71,7 @@ impl Caboose {
             return Ok(&data[data_start..][..data_len]);
         }
 
-        Err(CabooseError::MissingTag { tag: tags::BORD })
+        Err(CabooseError::MissingTag { tag })
     }
 }
 

--- a/hubtools/src/lib.rs
+++ b/hubtools/src/lib.rs
@@ -489,6 +489,11 @@ impl RawHubrisArchive {
         Ok(out)
     }
 
+    /// Extract the TLVC-encoded auxiliary image file from the ZIP archive
+    pub fn auxiliary_image(&self) -> Result<Vec<u8>, Error> {
+        self.extract_file("img/auxi.tlvc")
+    }
+
     /// Extracts a file from the ZIP archive by name
     pub fn extract_file(&self, name: &str) -> Result<Vec<u8>, Error> {
         let cursor = Cursor::new(self.zip.as_slice());


### PR DESCRIPTION
This adds a handful of things that would let MGS use `hubtools` instead of having its own hubris archive stuff:

1. `RawHubrisArchive` can be opened from a `Vec<u8>`, not just a file on disk
2. Add an `auxiliary_image()` helper method
3. Make `read_caboose()` return a `Caboose` instead of a `Vec<u8>`, and add a method on `Caboose` to parse and read the `BORD` value

(MGS doesn't do the 3rd item today, but it would be nice if it could!).