### PR TITLE
Remove commands which assume the presence of cmpa/cfpa in the archive

### DIFF
--- a/hubedit/Cargo.toml
+++ b/hubedit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hubedit"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/hubedit/src/main.rs
+++ b/hubedit/src/main.rs
@@ -37,10 +37,6 @@ pub enum Command {
         #[clap(short, long)]
         force: bool,
     },
-    VerifyImage {
-        #[clap(short, long)]
-        verbose: bool,
-    },
     /// Replaces the binary image within an archive with a different binary
     /// image, supplied on the command line as a raw (BIN) file.
     ///
@@ -118,9 +114,6 @@ fn main() -> Result<()> {
             }
             archive.erase_caboose()?;
             archive.overwrite()?;
-        }
-        Command::VerifyImage { verbose } => {
-            archive.verify(verbose)?;
         }
         Command::ReplaceImage { image } => {
             let contents = std::fs::read(&image).with_context(|| {

--- a/hubtools/Cargo.toml
+++ b/hubtools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hubtools"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.66"
 

--- a/hubtools/Cargo.toml
+++ b/hubtools/Cargo.toml
@@ -6,7 +6,6 @@ rust-version = "1.66"
 
 [dependencies]
 object = { version = "0.30", default-features = false, features = ["write", "read"] }
-packed_struct = { version = "0.10", default-features = false, features = ["std"] }
 path-slash = { version = "0.1", default-features = false }
 thiserror = { version = "1", default-features = false }
 toml = { version = "0.7", default-features = false, features = ["parse"] }

--- a/hubtools/src/lib.rs
+++ b/hubtools/src/lib.rs
@@ -740,29 +740,6 @@ impl RawHubrisArchive {
         Ok(())
     }
 
-    /// Verifies the signature of an LPC55 image
-    ///
-    /// Results are printed to `stderr` using `log`
-    pub fn verify(&self, verbose: bool) -> Result<(), Error> {
-        // CMPA and CFPA are included in the archive (for now)
-        let cmpa_bytes = self.extract_file("img/CMPA.bin")?;
-        let cmpa_array: Box<[u8; 512]> = cmpa_bytes
-            .try_into()
-            .map_err(|v: Vec<u8>| Error::BadCMPASize(v.len()))?;
-        let cmpa = lpc55_areas::CMPAPage::from_bytes(&cmpa_array)?;
-
-        let cfpa_bytes = self.extract_file("img/CFPA.bin")?;
-        let cfpa_array: Box<[u8; 512]> = cfpa_bytes
-            .try_into()
-            .map_err(|v: Vec<u8>| Error::BadCFPASize(v.len()))?;
-        let cfpa = lpc55_areas::CFPAPage::from_bytes(&cfpa_array)?;
-
-        lpc55_sign::verify::init_verify_logger(verbose);
-        lpc55_sign::verify::verify_image(&self.image.data, cmpa, cfpa)?;
-
-        Ok(())
-    }
-
     /// Signs the given image with a chain of one-or-more certificates
     ///
     /// This modifies local data in memory; call `self.overwrite` to persist


### PR DESCRIPTION
Canonical CMPA / CPFA comes from bootleby; these files are unused and we're them from the Hubris archive in https://github.com/oxidecomputer/hubris/pull/1411