### PR TITLE
Set NAME as the patched name when `patches.toml` is present

### DIFF
--- a/hubtools/Cargo.toml
+++ b/hubtools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hubtools"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.66"
 

--- a/hubtools/src/lib.rs
+++ b/hubtools/src/lib.rs
@@ -598,8 +598,6 @@ impl RawHubrisArchive {
 
             if let Some(n) = patches
                 .as_table()
-                .and_then(|p| p.get("patches"))
-                .and_then(|p| p.as_table())
                 .and_then(|p| p.get("name"))
                 .and_then(|p| p.as_str())
             {


### PR DESCRIPTION
Previously, images that used inheritance had the `NAME` of the parent file in their caboose.  This PR switches over to using the patched name instead.