### PR TITLE
Add `HubrisArchiveBuilder` to create hubris archives from raw images or thin air

### DIFF
--- a/hubtools/src/archive_builder.rs
+++ b/hubtools/src/archive_builder.rs
@@ -14,7 +14,7 @@ use zip::ZipWriter;
 ///
 /// Currently the archives produced by `HubrisArchiveBuilder` only contain the
 /// final hubris image (in both binary and ELF format), and are therefore likely
-/// unsuitable for many uses (including humility). The intented use for this
+/// unsuitable for many uses (including humility). The intended use for this
 /// (again, for now) is generating test data; see
 /// [`HubrisArchiveBuilder::with_fake_image()`].
 pub struct HubrisArchiveBuilder {
@@ -104,6 +104,8 @@ impl HubrisArchiveBuilder {
         archive.start_file("img/final.elf", opts)?;
         let elf = self.image.to_elf()?;
         archive.write_all(&elf).unwrap();
+
+        archive.start_file("img/final.bin", opts)?;
         let bin = self.image.to_binary()?;
         archive.write_all(&bin).unwrap();
 

--- a/hubtools/src/archive_builder.rs
+++ b/hubtools/src/archive_builder.rs
@@ -1,0 +1,162 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::header;
+use crate::Error;
+use crate::RawHubrisImage;
+use crate::CABOOSE_MAGIC;
+use std::io;
+use std::io::Write;
+use zip::ZipWriter;
+
+/// `HubrisArchiveBuilder` can create an extremely minimal hubris archive.
+///
+/// Currently the archives produced by `HubrisArchiveBuilder` only contain the
+/// final hubris image (in both binary and ELF format), and are therefore likely
+/// unsuitable for many uses (including humility). The intented use for this
+/// (again, for now) is generating test data; see
+/// [`HubrisArchiveBuilder::with_fake_image()`].
+pub struct HubrisArchiveBuilder {
+    image: RawHubrisImage,
+    archive_version: u32,
+}
+
+impl HubrisArchiveBuilder {
+    pub fn with_image(image: RawHubrisImage) -> Self {
+        Self {
+            image,
+            archive_version: 0,
+        }
+    }
+
+    /// Construct a fake `RawHubrisImage` that is not valid, but _appears_ to be
+    /// valid: it contains the correct magic numbers at the correct offsets to
+    /// look like a hubris image and contain a caboose.
+    pub fn with_fake_image() -> Self {
+        const FAKE_IMAGE_SIZE: usize = 1024;
+        const FAKE_CABOOSE_SIZE: usize = 256;
+
+        // Built a dummy image that still looks reasonable enough for testing
+        // (e.g, we stick some magic values in the right places and allow for
+        // insertion of a caboose).
+        let mut data = io::Cursor::new(vec![0; FAKE_IMAGE_SIZE]);
+
+        // Write the header magic at the largest possible value where
+        // `RawHubrisArchive` might look for it.
+        data.set_position(u64::from(
+            header::POSSIBLE_OFFSETS.iter().copied().max().unwrap(),
+        ));
+        data.write_all(&header::MAGIC.last().copied().unwrap().to_le_bytes())
+            .unwrap();
+
+        // Write the image size immediately after the header magic.
+        data.write_all(&(FAKE_IMAGE_SIZE as u32).to_le_bytes())
+            .unwrap();
+
+        // Write the caboose magic at the beginning of the caboose.
+        data.set_position((FAKE_IMAGE_SIZE - FAKE_CABOOSE_SIZE) as u64);
+        data.write_all(&CABOOSE_MAGIC.to_le_bytes()).unwrap();
+
+        // Write the caboose size as the last word in the image.
+        data.set_position((FAKE_IMAGE_SIZE - 4) as u64);
+        data.write_all(&(FAKE_CABOOSE_SIZE as u32).to_le_bytes())
+            .unwrap();
+
+        let image =
+            RawHubrisImage::from_binary(data.into_inner(), 0, 0).unwrap();
+
+        // Ensure our caboose staging above was correct.
+        assert_eq!(
+            (FAKE_IMAGE_SIZE - FAKE_CABOOSE_SIZE + 4) as u32
+                ..FAKE_IMAGE_SIZE as u32 - 4,
+            image.caboose_range().unwrap()
+        );
+
+        Self::with_image(image)
+    }
+
+    /// Set the version number including in the zip file comment.
+    pub fn archive_version(&mut self, archive_version: u32) -> &mut Self {
+        self.archive_version = archive_version;
+        self
+    }
+
+    /// Overwrite the caboose of the image included in this archive.
+    pub fn write_caboose(&mut self, data: &[u8]) -> Result<&mut Self, Error> {
+        self.image.write_caboose(data)?;
+        Ok(self)
+    }
+
+    pub fn build<W>(self, out: W) -> Result<W, Error>
+    where
+        W: io::Write + io::Seek,
+    {
+        let opts = zip::write::FileOptions::default()
+            .compression_method(zip::CompressionMethod::Bzip2);
+
+        let mut archive = ZipWriter::new(out);
+        archive.set_comment(format!(
+            "hubris build archive v{}",
+            self.archive_version
+        ));
+
+        archive.start_file("img/final.elf", opts)?;
+        let elf = self.image.to_elf()?;
+        archive.write_all(&elf).unwrap();
+        let bin = self.image.to_binary()?;
+        archive.write_all(&bin).unwrap();
+
+        let out = archive.finish()?;
+        Ok(out)
+    }
+
+    pub fn build_to_vec(self) -> Result<Vec<u8>, Error> {
+        let out = io::Cursor::new(Vec::new());
+        self.build(out).map(io::Cursor::into_inner)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CabooseBuilder;
+    use crate::RawHubrisArchive;
+
+    #[test]
+    fn built_archives_are_loadable() {
+        let builder = HubrisArchiveBuilder::with_fake_image();
+        let archive = builder.build_to_vec().unwrap();
+
+        let loaded = RawHubrisArchive::from_vec(archive).unwrap();
+        let caboose = loaded.read_caboose().unwrap();
+
+        // We didn't specify any caboose contents, so it should be empty.
+        assert!(caboose.as_slice().iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn written_caboose_values_are_loadable() {
+        let mut builder = HubrisArchiveBuilder::with_fake_image();
+        builder
+            .write_caboose(
+                CabooseBuilder::default()
+                    .git_commit("foo")
+                    .board("bar")
+                    .name("fizz")
+                    .version("buzz")
+                    .build()
+                    .as_slice(),
+            )
+            .unwrap();
+        let archive = builder.build_to_vec().unwrap();
+
+        let loaded = RawHubrisArchive::from_vec(archive).unwrap();
+        let caboose = loaded.read_caboose().unwrap();
+
+        assert_eq!(caboose.git_commit(), Ok("foo".as_bytes()));
+        assert_eq!(caboose.board(), Ok("bar".as_bytes()));
+        assert_eq!(caboose.name(), Ok("fizz".as_bytes()));
+        assert_eq!(caboose.version(), Ok("buzz".as_bytes()));
+    }
+}

--- a/hubtools/src/caboose.rs
+++ b/hubtools/src/caboose.rs
@@ -5,7 +5,7 @@
 use std::mem;
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum CabooseError {
     #[error("error reading caboose: {0:?}")]
     TlvcReadError(tlvc::TlvcReadError<std::convert::Infallible>),
@@ -80,4 +80,109 @@ pub(crate) mod tags {
     pub(crate) const BORD: [u8; 4] = *b"BORD";
     pub(crate) const NAME: [u8; 4] = *b"NAME";
     pub(crate) const VERS: [u8; 4] = *b"VERS";
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct CabooseBuilder {
+    git_commit: Option<String>,
+    board: Option<String>,
+    name: Option<String>,
+    version: Option<String>,
+}
+
+impl CabooseBuilder {
+    pub fn git_commit<S: Into<String>>(mut self, git_commit: S) -> Self {
+        self.git_commit = Some(git_commit.into());
+        self
+    }
+
+    pub fn board<S: Into<String>>(mut self, board: S) -> Self {
+        self.board = Some(board.into());
+        self
+    }
+
+    pub fn name<S: Into<String>>(mut self, name: S) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    pub fn version<S: Into<String>>(mut self, version: S) -> Self {
+        self.version = Some(version.into());
+        self
+    }
+
+    pub fn build(self) -> Caboose {
+        let mut pieces = Vec::new();
+        for (tag, maybe_value) in [
+            (tags::GITC, self.git_commit),
+            (tags::BORD, self.board),
+            (tags::NAME, self.name),
+            (tags::VERS, self.version),
+        ] {
+            let Some(value) = maybe_value else { continue; };
+            pieces.push(tlvc_text::Piece::Chunk(
+                tlvc_text::Tag::new(tag),
+                vec![tlvc_text::Piece::String(value)],
+            ));
+        }
+        Caboose::new(tlvc_text::pack(&pieces))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_builder_makes_empty_caboose() {
+        let caboose = CabooseBuilder::default().build();
+        assert_eq!(
+            caboose.git_commit(),
+            Err(CabooseError::MissingTag { tag: tags::GITC })
+        );
+        assert_eq!(
+            caboose.board(),
+            Err(CabooseError::MissingTag { tag: tags::BORD })
+        );
+        assert_eq!(
+            caboose.name(),
+            Err(CabooseError::MissingTag { tag: tags::NAME })
+        );
+        assert_eq!(
+            caboose.version(),
+            Err(CabooseError::MissingTag { tag: tags::VERS })
+        );
+    }
+
+    #[test]
+    fn builder_can_make_caboose_with_one_tag() {
+        let caboose = CabooseBuilder::default().git_commit("foo").build();
+        assert_eq!(caboose.git_commit(), Ok("foo".as_bytes()));
+        assert_eq!(
+            caboose.board(),
+            Err(CabooseError::MissingTag { tag: tags::BORD })
+        );
+        assert_eq!(
+            caboose.name(),
+            Err(CabooseError::MissingTag { tag: tags::NAME })
+        );
+        assert_eq!(
+            caboose.version(),
+            Err(CabooseError::MissingTag { tag: tags::VERS })
+        );
+    }
+
+    #[test]
+    fn builder_can_make_caboose_with_all_tags() {
+        let caboose = CabooseBuilder::default()
+            .git_commit("foo")
+            .board("bar")
+            .name("fizz")
+            .version("buzz")
+            .build();
+        assert_eq!(caboose.git_commit(), Ok("foo".as_bytes()));
+        assert_eq!(caboose.board(), Ok("bar".as_bytes()));
+        assert_eq!(caboose.name(), Ok("fizz".as_bytes()));
+        assert_eq!(caboose.version(), Ok("buzz".as_bytes()));
+    }
 }

--- a/hubtools/src/lib.rs
+++ b/hubtools/src/lib.rs
@@ -13,8 +13,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
+mod archive_builder;
 mod caboose;
 
+pub use archive_builder::HubrisArchiveBuilder;
 pub use caboose::{Caboose, CabooseBuilder, CabooseError};
 
 #[derive(Debug)]
@@ -250,11 +252,82 @@ impl RawHubrisImage {
     pub fn replace(&mut self, data: Vec<u8>) {
         self.data = data;
     }
+
+    fn caboose_range(&self) -> Result<std::ops::Range<u32>, Error> {
+        let mut found_header = None;
+        let start_addr = self.start_addr;
+
+        for header_offset in header::POSSIBLE_OFFSETS {
+            let mut header_magic = 0u32;
+            self.read(start_addr + header_offset, &mut header_magic)?;
+            if header::MAGIC.contains(&header_magic) {
+                found_header = Some(header_offset);
+                break;
+            }
+        }
+
+        let Some(header_offset) = found_header else {
+            return Err(Error::MissingMagic(header::MAGIC));
+        };
+
+        let mut image_size = 0u32;
+        self.read(start_addr + header_offset + 4, &mut image_size)?;
+
+        let mut caboose_size = 0u32;
+        self.read(start_addr + image_size - 4, &mut caboose_size)?;
+
+        let mut caboose_magic = 0u32;
+        let caboose_magic_addr = (start_addr + image_size)
+            .checked_sub(caboose_size)
+            .ok_or(Error::MissingCaboose)?;
+        self.read(caboose_magic_addr, &mut caboose_magic)?;
+        if caboose_magic != CABOOSE_MAGIC {
+            return Err(Error::BadCabooseMagic(CABOOSE_MAGIC, caboose_magic))?;
+        }
+        Ok(start_addr + image_size - caboose_size + 4
+            ..start_addr + image_size - 4)
+    }
+
+    /// Writes to the caboose in local memory
+    fn write_caboose(&mut self, data: &[u8]) -> Result<(), Error> {
+        // Skip the start and end word, which are markers
+        let caboose_range = self.caboose_range()?;
+
+        let end = caboose_range.end - self.start_addr;
+        if end as usize != self.data.len() - 4 {
+            Err(Error::BadCabooseLocation)
+        } else if data.len() > caboose_range.len() {
+            Err(Error::OversizedData(data.len(), caboose_range.len()))
+        } else {
+            self.write(caboose_range.start, data)
+        }
+    }
+
+    /// Attempts to read `out.len()` bytes, starting at `start`
+    fn read<T: AsBytes + FromBytes + ?Sized>(
+        &self,
+        start: u32,
+        out: &mut T,
+    ) -> Result<(), Error> {
+        let size = out.as_bytes().len() as u32;
+        out.as_bytes_mut()
+            .copy_from_slice(self.get(start..start + size)?);
+        Ok(())
+    }
+
+    /// Attempts to read `out.len()` bytes, starting at `start`
+    fn write<T: AsBytes + FromBytes + ?Sized>(
+        &mut self,
+        start: u32,
+        input: &T,
+    ) -> Result<(), Error> {
+        let size = input.as_bytes().len() as u32;
+        self.get_mut(start..start + size)?
+            .copy_from_slice(input.as_bytes());
+        Ok(())
+    }
 }
 
-// Defined in the kernel ABI crate - we support both the original and new-style
-// magic numbers, which use the same header layout.
-const HEADER_MAGIC: [u32; 2] = [0x15356637, 0x64_CE_D6_CA];
 const CABOOSE_MAGIC: u32 = 0xcab0005e;
 
 #[derive(Error, Debug)]
@@ -442,57 +515,12 @@ impl RawHubrisArchive {
         }
     }
 
-    fn start_addr(&self) -> u32 {
-        self.image.start_addr
-    }
-
-    fn caboose_range(&self) -> Result<std::ops::Range<u32>, Error> {
-        let mut found_header = None;
-        let start_addr = self.start_addr();
-
-        // The header is located in one of a few locations, depending on MCU
-        // and versions of the PAC crates.
-        //
-        // - 0xbc and 0xc0 are possible values for the STM32G0
-        // - 0x298 is for the STM32H7
-        // - 0x130 is for the LPC55
-        for header_offset in [0xbc, 0xc0, 0x130, 0x298] {
-            let mut header_magic = 0u32;
-            self.read(start_addr + header_offset, &mut header_magic)?;
-            if HEADER_MAGIC.contains(&header_magic) {
-                found_header = Some(header_offset);
-                break;
-            }
-        }
-
-        let Some(header_offset) = found_header else {
-            return Err(Error::MissingMagic(HEADER_MAGIC));
-        };
-
-        let mut image_size = 0u32;
-        self.read(start_addr + header_offset + 4, &mut image_size)?;
-
-        let mut caboose_size = 0u32;
-        self.read(start_addr + image_size - 4, &mut caboose_size)?;
-
-        let mut caboose_magic = 0u32;
-        let caboose_magic_addr = (start_addr + image_size)
-            .checked_sub(caboose_size)
-            .ok_or(Error::MissingCaboose)?;
-        self.read(caboose_magic_addr, &mut caboose_magic)?;
-        if caboose_magic != CABOOSE_MAGIC {
-            return Err(Error::BadCabooseMagic(CABOOSE_MAGIC, caboose_magic))?;
-        }
-        Ok(start_addr + image_size - caboose_size + 4
-            ..start_addr + image_size - 4)
-    }
-
     /// Reads the caboose from local memory
     pub fn read_caboose(&self) -> Result<Caboose, Error> {
         // Skip the start and end word, which are markers
-        let caboose_range = self.caboose_range()?;
+        let caboose_range = self.image.caboose_range()?;
         let mut out = vec![0u8; caboose_range.len()];
-        self.read(caboose_range.start, out.as_mut_slice())?;
+        self.image.read(caboose_range.start, out.as_mut_slice())?;
         Ok(Caboose::new(out))
     }
 
@@ -525,17 +553,7 @@ impl RawHubrisArchive {
     ///
     /// [`overwrite`] must be called to write these changes back to disk.
     pub fn write_caboose(&mut self, data: &[u8]) -> Result<(), Error> {
-        // Skip the start and end word, which are markers
-        let caboose_range = self.caboose_range()?;
-
-        let end = caboose_range.end - self.image.start_addr;
-        if end as usize != self.image.data.len() - 4 {
-            Err(Error::BadCabooseLocation)
-        } else if data.len() > caboose_range.len() {
-            Err(Error::OversizedData(data.len(), caboose_range.len()))
-        } else {
-            self.write(caboose_range.start, data)
-        }
+        self.image.write_caboose(data)
     }
 
     /// Writes the given version (and nothing else) to the caboose
@@ -545,7 +563,7 @@ impl RawHubrisArchive {
     ) -> Result<(), Error> {
         // Manually build the TLV-C data for the caboose
         let data = tlvc_text::Piece::Chunk(
-            tlvc_text::Tag::new(*b"VERS"),
+            tlvc_text::Tag::new(caboose::tags::VERS),
             vec![tlvc_text::Piece::String(version.to_owned())],
         );
         let out = tlvc_text::pack(&[data]);
@@ -637,13 +655,13 @@ impl RawHubrisArchive {
     ///
     /// [`overwrite`] must be called to write these changes back to disk.
     pub fn erase_caboose(&mut self) -> Result<(), Error> {
-        let caboose_range = self.caboose_range()?;
+        let caboose_range = self.image.caboose_range()?;
         let end = caboose_range.end - self.image.start_addr;
         if end as usize != self.image.data.len() - 4 {
             return Err(Error::BadCabooseLocation);
         }
         let data = vec![0xFFu8; caboose_range.len()];
-        self.write(caboose_range.start, data.as_slice())
+        self.image.write(caboose_range.start, data.as_slice())
     }
 
     /// Checks whether the caboose is empty in local memory
@@ -719,31 +737,6 @@ impl RawHubrisArchive {
         Ok(())
     }
 
-    /// Attempts to read `out.len()` bytes, starting at `start`
-    fn read<T: AsBytes + FromBytes + ?Sized>(
-        &self,
-        start: u32,
-        out: &mut T,
-    ) -> Result<(), Error> {
-        let size = out.as_bytes().len() as u32;
-        out.as_bytes_mut()
-            .copy_from_slice(self.image.get(start..start + size)?);
-        Ok(())
-    }
-
-    /// Attempts to read `out.len()` bytes, starting at `start`
-    fn write<T: AsBytes + FromBytes + ?Sized>(
-        &mut self,
-        start: u32,
-        input: &T,
-    ) -> Result<(), Error> {
-        let size = input.as_bytes().len() as u32;
-        self.image
-            .get_mut(start..start + size)?
-            .copy_from_slice(input.as_bytes());
-        Ok(())
-    }
-
     /// Signs the given image with a chain of one-or-more certificates
     ///
     /// This modifies local data in memory; call `self.overwrite` to persist
@@ -796,4 +789,18 @@ impl RawHubrisArchive {
     pub fn replace(&mut self, data: Vec<u8>) {
         self.image.replace(data);
     }
+}
+
+mod header {
+    // Defined in the kernel ABI crate - we support both the original and
+    // new-style magic numbers, which use the same header layout.
+    pub(crate) const MAGIC: [u32; 2] = [0x15356637, 0x64_CE_D6_CA];
+
+    // The header is located in one of a few locations, depending on MCU
+    // and versions of the PAC crates.
+    //
+    // - 0xbc and 0xc0 are possible values for the STM32G0
+    // - 0x298 is for the STM32H7
+    // - 0x130 is for the LPC55
+    pub(crate) const POSSIBLE_OFFSETS: [u32; 4] = [0xbc, 0xc0, 0x130, 0x298];
 }

--- a/hubtools/src/lib.rs
+++ b/hubtools/src/lib.rs
@@ -15,7 +15,7 @@ use std::{
 
 mod caboose;
 
-pub use caboose::{Caboose, CabooseError};
+pub use caboose::{Caboose, CabooseBuilder, CabooseError};
 
 #[derive(Debug)]
 pub struct RawHubrisImage {


### PR DESCRIPTION
My immediate goal with this is to be able to generate _fake_ hubris archives for integration tests in omicron, and as of this PR `HubrisArchiveBuilder` is probably only useful for that. I tried not to close the door on it potentially being useful to generate a real hubris archive from a standalone image, but it will need some additions for that to be useful (e.g., adding an `app.toml` for humility).