### PR TITLE
Add hubris re-stamp function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["hubedit", "hubtools"]
+resolver = "2"
 
 [workspace.dependencies]
 hubtools.path = "hubtools"

--- a/hubtools/Cargo.toml
+++ b/hubtools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hubtools"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 rust-version = "1.66"
 

--- a/hubtools/src/caboose.rs
+++ b/hubtools/src/caboose.rs
@@ -119,7 +119,9 @@ impl CabooseBuilder {
             (tags::NAME, self.name),
             (tags::VERS, self.version),
         ] {
-            let Some(value) = maybe_value else { continue; };
+            let Some(value) = maybe_value else {
+                continue;
+            };
             pieces.push(tlvc_text::Piece::Chunk(
                 tlvc_text::Tag::new(tag),
                 vec![tlvc_text::Piece::String(value)],


### PR DESCRIPTION
For use with permission slip for signing/tagging artifacts, add an API to remove a signature and prep an image for signing.