### PR TITLE
Ignore error from unsign and clippy fixes

### DIFF
--- a/hubtools/Cargo.toml
+++ b/hubtools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hubtools"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 rust-version = "1.66"
 

--- a/hubtools/src/lib.rs
+++ b/hubtools/src/lib.rs
@@ -766,7 +766,7 @@ impl RawHubrisArchive {
         private_key: &rsa::RsaPrivateKey,
         execution_address: u32,
     ) -> Result<(), Error> {
-        let _ = self.is_lpc55()?;
+        self.is_lpc55()?;
 
         self.image.sign(
             signing_certs,
@@ -808,7 +808,7 @@ impl RawHubrisArchive {
     ) -> Result<Vec<u8>, Error> {
         match self.is_lpc55() {
             Ok(_) => {
-                let _ = self.unsign()?;
+                let _ = self.unsign();
                 // Need to write the caboose _after_ we unsign
                 self.write_default_caboose(version)?;
                 let stamped = lpc55_sign::signed_image::stamp_image(
@@ -834,7 +834,7 @@ impl RawHubrisArchive {
                 let mut b = self.image.to_binary()?;
                 b.extend_from_slice(sig);
                 self.replace(b);
-                return Ok(());
+                Ok(())
             }
             // Do nothing on non LPC55 chips at the moment
             Err(_) => Ok(()),
@@ -843,7 +843,7 @@ impl RawHubrisArchive {
 
     /// Strips any existing signature from the image.
     pub fn unsign(&mut self) -> Result<(), Error> {
-        let _ = self.is_lpc55()?;
+        self.is_lpc55()?;
         self.image.unsign()
     }
 


### PR DESCRIPTION
This only affects images being signed for the first time