### PR TITLE
Save the signature for non lpc55 targets

### DIFF
--- a/hubtools/Cargo.toml
+++ b/hubtools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hubtools"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 rust-version = "1.66"
 

--- a/hubtools/src/lib.rs
+++ b/hubtools/src/lib.rs
@@ -836,8 +836,12 @@ impl RawHubrisArchive {
                 self.replace(b);
                 Ok(())
             }
-            // Do nothing on non LPC55 chips at the moment
-            Err(_) => Ok(()),
+            Err(_) => {
+                // Save the signature as signature.txt for now until we
+                // figure out what to do with it
+                self.add_file("signature.txt", sig)?;
+                Ok(())
+            }
         }
     }
 


### PR DESCRIPTION
We're going to sign the stm32h7 but not actually append it to the image until we figure out what makes sense