### PR TITLE
Append SIGN information in the caboose

### DIFF
--- a/hubtools/Cargo.toml
+++ b/hubtools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hubtools"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 rust-version = "1.66"
 
@@ -12,6 +12,7 @@ toml = { version = "0.7", default-features = false, features = ["parse"] }
 x509-cert = { version = "0.2", default-features = false, features = ["std"] }
 zerocopy = { version = "0.6", default-features = false }
 zip = { version = "0.6", default-features = false, features = ["bzip2"] }
+hex = { version = "0.4.3", default-features = false }
 
 tlvc = { git = "https://github.com/oxidecomputer/tlvc", default-features = false, version = "0.3" }
 tlvc-text = { git = "https://github.com/oxidecomputer/tlvc", default-features = false, version = "0.3" }

--- a/hubtools/src/bootleby.rs
+++ b/hubtools/src/bootleby.rs
@@ -62,8 +62,7 @@ fn add_image_header(path: PathBuf) -> Result<Vec<u8>, Error> {
     // work on the file path and return the bytes
     let mut f = std::fs::read(path).map_err(Error::FileReadError)?;
 
-    let elf =
-        object::read::File::parse(&*f).map_err(Error::ObjectError)?;
+    let elf = object::read::File::parse(&*f).map_err(Error::ObjectError)?;
     if elf.format() != object::BinaryFormat::Elf {
         return Err(Error::NotAnElf(elf.format()));
     }

--- a/hubtools/src/caboose.rs
+++ b/hubtools/src/caboose.rs
@@ -80,6 +80,7 @@ pub(crate) mod tags {
     pub(crate) const BORD: [u8; 4] = *b"BORD";
     pub(crate) const NAME: [u8; 4] = *b"NAME";
     pub(crate) const VERS: [u8; 4] = *b"VERS";
+    pub(crate) const SIGN: [u8; 4] = *b"SIGN";
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]


### PR DESCRIPTION
It's useful to have some information about what was used to sign an archive, add the hash of the root certs as a piece of identifying information