### PR TITLE
Add a rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.76"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Specify a newer toolchain to avoid issues with clap

```
error: package `clap v4.5.0` cannot be built because it requires rustc
1.74 or newer, while the currently active rustc version is 1.72.1
```