### PR TITLE
fwidgen: Add tool to generate FWID for the image in a hubris archive.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
@@ -175,9 +175,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.0"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.0"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.0"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -210,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
@@ -335,9 +335,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -354,6 +354,18 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "fwidgen"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "hex",
+ "hubtools",
+ "sha3",
+ "toml",
+]
 
 [[package]]
 name = "generic-array"
@@ -399,9 +411,9 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -472,8 +484,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
  "hermit-abi",
- "rustix",
+ "rustix 0.38.31",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -487,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libm"
@@ -502,6 +523,12 @@ name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "log"
@@ -795,7 +822,20 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.13",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.3",
  "windows-sys 0.52.0",
 ]
 
@@ -832,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -848,6 +888,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]
@@ -942,12 +992,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.3.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix",
- "windows-sys 0.48.0",
+ "rustix 1.0.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1026,9 +1076,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
@@ -1109,135 +1159,85 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.52.0"
+name = "windows_i686_gnullvm"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["hubedit", "hubtools"]
+members = ["fwidgen", "hubedit", "hubtools"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/fwidgen/Cargo.toml
+++ b/fwidgen/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "fwidgen"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow.version = "1"
+clap = { version = "4.5.32", features = ["derive", "env", "wrap_help"] }
+hex = "0.4.3"
+hubtools.workspace = true
+sha3 = { version = "0.10.8", default-features = false }
+toml = { version = "0.7.8", default-features = false, features = ["parse"] }

--- a/fwidgen/src/main.rs
+++ b/fwidgen/src/main.rs
@@ -1,0 +1,171 @@
+use anyhow::{anyhow, Context, Result};
+use clap::Parser;
+use hubtools::RawHubrisArchive;
+use sha3::{Digest, Sha3_256};
+use std::{
+    str,
+    ops::Range,
+};
+
+pub const LPC55_FLASH_PAGE_SIZE: usize = 512;
+
+/// This tool calculates what we call the FWID for supported hubris images and
+/// prints them as a hex string. This value is just a digest that's calculated
+/// by the hubris measured boot implementation and stored in the `DiceTcbInfo`
+/// x509 extension of our attestation leaf cert.
+///
+/// This tool exists to:
+/// 1) allow appraisers to evaluate the FWID values produced by an attestation
+/// from an RoT and associate them with a particular hubris archive
+/// 2) to assist in the construction of a measurement corpus from a collection
+/// of hubris archives
+#[derive(Parser, Debug)]
+struct Args {
+    /// Hubris archive
+    #[clap(env = "HUBEDIT_ARCHIVE")]
+    archive: String,
+}
+
+#[derive(Debug)]
+enum Chip {
+    Lpc55,
+    Stm32,
+}
+
+impl TryFrom<&RawHubrisArchive> for Chip {
+    type Error = anyhow::Error;
+
+    fn try_from(archive: &RawHubrisArchive) -> Result<Self> {
+        let manifest = archive.extract_file("app.toml")?;
+        let manifest: toml::Value = toml::from_str(
+            str::from_utf8(&manifest).context("manifest bytes to UTF8")?,
+        ).context("manifest UTF8 to TOML")?;
+
+        let chip = manifest
+           .as_table()
+           .ok_or(anyhow!("manifest isn't a table"))?
+           .get("chip")
+           .ok_or(anyhow!("no key \"chip\" in manifest"))?
+           .as_str()
+           .ok_or(anyhow!("value for key \"chip\" isn't a string"))?;
+
+        if chip.contains("lpc55") {
+            Ok(Chip::Lpc55)
+        } else if chip.contains("stm32") {
+            Ok(Chip::Stm32)
+        } else {
+            Err(anyhow!("Unsupported chip: {}", chip))
+        }
+    }
+}
+
+// Return a Range describing the named flash range from memory.toml).
+fn get_flash_range(name: &str, archive: &RawHubrisArchive) -> Result<Range<u32>> {
+    let memory = archive.extract_file("memory.toml")
+        .context("extract memory.toml from archive")?;
+    let memory: toml::Value = toml::from_str(
+        str::from_utf8(&memory).context("memory.toml bytes to UTF8")?,
+    ).context("memory.toml UTF8 to TOML")?;
+
+    // this may be easier w/ a derive macro for TOML -> Rust types / instances
+    for value in memory
+        .as_table()
+        .ok_or(anyhow!("no table in memory.toml"))?
+        .get("flash")
+        .ok_or(anyhow!("no value with key \"flash\" memory.toml table"))?
+        .as_array()
+        .ok_or(anyhow!("value from key \"flash\" in memory.toml is not an array"))?
+    {
+        let name_toml = value
+            .get("name")
+            .ok_or(anyhow!("no key \"name\" found in memory.toml \"flash\""))?
+            .as_str()
+            .ok_or(anyhow!("value for key \"name\" isn't a string"))?;
+
+        if name == name_toml {
+            let start: u32 = value
+                .get("address")
+                .ok_or(anyhow!("no key \"address\" found in flash table \"a\""))?
+                .as_integer()
+                .ok_or(anyhow!("value for key \"address\" isn't an integer"))?
+                .try_into()
+                .context("convert address from memory table to u32")?;
+            let size: u32 = value
+                .get("size")
+                .ok_or(anyhow!("no key \"size\" found in table \"a\""))?
+                .as_integer()
+                .ok_or(anyhow!("value for key \"size\" isn't an integer"))?
+                .try_into()
+                .context("convert size from memory table to u32")?;
+            let end = start + size;
+
+            return Ok(Range { start, end });
+        }
+    }
+
+    return Err(anyhow!("No flash range for image \"{}\"", name));
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let archive = RawHubrisArchive::load(&args.archive)
+        .context("Load RawHubrisArchive")?;
+
+    let image = archive.image.to_binary()
+        .context("Archive image to binary")?;
+
+    let chip = Chip::try_from(&archive)?;
+
+    // When calculating the FWID value we aim to capture *all* data from the
+    // relevant flash region. The hubris image will reside in one contiguous
+    // range identical to the image from the archive however all flash pages
+    // within the remaining flash region must be represented in the FWID as
+    // well. We do this to ensure flash pages not used by the hubris image
+    // are in the expected state. Doing this here requires that we accomodate
+    // some chip-specific quirks here:
+    let pad = match chip {
+        Chip::Lpc55 => {
+            // On the Lpc55s flash pages that haven't had any data written to
+            // them cannot be read. Unused regions of a flash page will
+            // return 0xff when read. Claculating the FWID then requires that
+            // we pad the final page in the hubris image with `0xff`.
+            //
+            // NOTE: We do *not* need any info about the flash region where
+            // this image will be written on the Lpc55s. The behavior of the
+            // flash on this chip means all pages from the end of the hubris
+            // image to the end of flash will be unwritten and thus
+            // unreadable.
+            LPC55_FLASH_PAGE_SIZE - image.len() % LPC55_FLASH_PAGE_SIZE
+        },
+        Chip::Stm32 => {
+            // On the stm32s flash pages that haven't had any data written to
+            // them will return 0xff. This includes flash pages that have
+            // been partially written. Calculating the FWID then requires
+            // that we pad the hubris image w/ `0xff` out to the end of its
+            // flash region. This requires we pull additional data from the
+            // hubris archive to get the dimensions of the flash range where
+            // the image will reside.
+            //
+            // NOTE: The hubris image that we run on stm32s is the SP and
+            // it is only ever written to a single flash range. We still
+            // look up the image name and get the flash range from the image
+            // manifest in an attempt to be flexible in the event this
+            // assumption becomes invalid.
+            let name = archive.image_name()?;
+            let flash = get_flash_range(&name, &archive)?;
+
+            flash.end as usize - flash.start as usize - image.len()
+        }
+    };
+
+    let mut digest = Sha3_256::new();
+    digest.update(&image);
+    digest.update(vec![0xff; pad]);
+
+    let digest = digest.finalize();
+
+    println!("{}", hex::encode(digest));
+
+    Ok(())
+}


### PR DESCRIPTION
This is an attempt to replace the `img/final.fwid` file generated by hubris `xtask` in the archive with a tool that can calculate t he value on demand. If we like the approach I'd like to extend this tool (or add another) to check the signature over the firmware image as a mechanism to establish trust in the FWID value.