### PR TITLE
Move license from workspace to workspace.package.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,9 @@
 [workspace]
 members = ["fwidgen", "hubedit", "hubtools"]
 resolver = "2"
-license = "MPL-2.0"
 
 [workspace.dependencies]
 hubtools.path = "hubtools"
+
+[workspace.package]
+license = "MPL-2.0"


### PR DESCRIPTION
For packages to inherit a license defined in the workspace it must be in `workspace.package`.